### PR TITLE
feat(common): support custom namer on initialize

### DIFF
--- a/namer.go
+++ b/namer.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Namer struct {
-	schema.NamingStrategy
+	NamingStrategy schema.Namer
 
 	CaseSensitive bool // whether naming is case-sensitive
 }
@@ -48,4 +48,12 @@ func (n Namer) CheckerName(table, column string) (name string) {
 
 func (n Namer) IndexName(table, column string) (name string) {
 	return n.ConvertNameToFormat(n.NamingStrategy.IndexName(table, column))
+}
+
+func (n Namer) SchemaName(table string) string {
+	return n.ConvertNameToFormat(n.NamingStrategy.SchemaName(table))
+}
+
+func (n Namer) UniqueName(table, column string) string {
+	return n.ConvertNameToFormat(n.NamingStrategy.UniqueName(table, column))
 }

--- a/oracle.go
+++ b/oracle.go
@@ -193,7 +193,7 @@ func (d Dialector) Name() string {
 
 func (d Dialector) Initialize(db *gorm.DB) (err error) {
 	db.NamingStrategy = Namer{
-		NamingStrategy: db.NamingStrategy.(schema.NamingStrategy),
+		NamingStrategy: db.NamingStrategy,
 		CaseSensitive:  d.NamingCaseSensitive,
 	}
 	d.DefaultStringSize = 1024


### PR DESCRIPTION
As described in issue #19 , we need customize our namer for oracle but the problem is only `schema.NamingStrategy` supported recently.

This pull request will solve the problem described in issue #19 .

Accepting this PR will close #19 .